### PR TITLE
Forcing usage of new version of glob-parent

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "dependencies": {
     "lodash-es": "^4.17.21",
     "moment": "^2.29.1"
+  },
+  "resolutions": {
+    "glob-parent": "^6.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1145,14 +1145,7 @@ glob-base@^0.3.0:
     glob-parent "^2.0.0"
     is-glob "^2.0.0"
 
-glob-parent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
-  integrity sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=
-  dependencies:
-    is-glob "^2.0.0"
-
-glob-parent@^6.0.2:
+glob-parent@^2.0.0, glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==


### PR DESCRIPTION
## What does this change?

Seeing if resolutions can resolve dependabot vulnerabilities