### PR TITLE
Enable nightly backups for the daily-edition-trial-periods table

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -223,3 +223,6 @@ Resources:
       TimeToLiveSpecification:
         AttributeName: "ttlTimestamp"
         Enabled: true
+      Tags:
+        - Key: devx-backup-enabled
+          Value: true


### PR DESCRIPTION
## What does this change?

This PR allows us to start backing up the `daily-edition-trial-periods` table using https://github.com/guardian/aws-backup. For more details on this project see [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit) and this [audit](https://docs.google.com/spreadsheets/d/1gNh_yQ3GVo_dVAemgZfRZM_MaQxep6_x-hzrhvVBGHY/edit#gid=1523470588) that @guardian/devx-reliability have been working on with Heads of Engineering.

N.B. the audit suggests that we want backups and I can see some data in this table, but the [README seems to imply](https://github.com/guardian/digital-subscription-authorisation/blob/daacf22b3cba13088a7940422166796cb4c659fb/README.md#L7) (to me) that this table may not be necessary these days - let me know if you have a strong opinion on this either way @rupertbates. 

## How to test

I should be able to test this by deploying to `CODE` (see `Deployment` section below).

I will double check that backups are taken as expected after merging (this should happen the night after this PR is merged).

## How can we measure success?

We will be able to recover (most) data stored in this table in the unlikely event that it is deleted.

## Have we considered potential risks?

Yes, a number of risks related to performance, cost and privacy were considered. See [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit#heading=h.vwt7syo8ng40) for more details.

## Deployment

As far as I can tell, this CloudFormation stack is deployed manually[^1].

If people are happy with this change in principle, I will:

- [ ] Manually update the `CODE` stack via the console (to check that this works)
- [ ] Merge the PR
- [ ] Manually update the `PROD` stack via the console

[^1]: There is no deployment of `type` [`cloud-formation`](https://riffraff.gutools.co.uk/docs/magenta-lib/types#cloudformation) in the [`riff-raff.yaml`](https://github.com/guardian/digital-subscription-authorisation/blob/daacf22b3cba13088a7940422166796cb4c659fb/riff-raff.yaml).